### PR TITLE
Add initial support for MCP 2025-06-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A fully-featured Haskell library for building [Model Context Protocol (MCP)](htt
 
 ## Features
 
-- **Complete MCP Implementation**: Supports MCP 2025-03-26 specification (with backward compatibility for 2024-11-05)
+- **Complete MCP Implementation**: Supports MCP 2025-06-18 specification (with backward compatibility for 2025-03-26 and 2024-11-05)
 - **Type-Safe API**: Leverage Haskell's type system for robust MCP servers
 - **Multiple Abstractions**: Both low-level fine-grained control and high-level derived interfaces
 - **Template Haskell Support**: Automatic handler derivation from data types
-- **Multiple Transports**: STDIO and HTTP Streaming transport (MCP 2025-03-26 Streamable HTTP)
+- **Multiple Transports**: STDIO and HTTP Streaming transport (MCP 2025-06-18 Streamable HTTP)
 
 ## Supported MCP Features
 
@@ -134,6 +134,23 @@ data SimpleTool
 
 All parameter types must ultimately resolve to records with named fields to generate proper MCP schemas.
 
+## MCP 2025-06-18 Features
+
+The library supports the latest MCP specification features:
+
+### Optional Metadata and Title Fields
+
+Prompts, resources, and tools can now include optional `title` and `_meta` fields:
+
+### Backward Compatibility
+
+The library maintains full backward compatibility:
+- **2025-06-18**: Latest features including `title` and `_meta` fields, HTTP protocol headers
+- **2025-03-26**: Previous version support without new fields
+- **2024-11-05**: Legacy version support
+
+Version negotiation happens automatically during the initialization handshake.
+
 ## Custom Descriptions
 
 You can provide custom descriptions for constructors and fields using the `*WithDescription` variants:
@@ -178,9 +195,9 @@ main = runMcpServerStdio serverInfo handlers
       }
 ```
 
-## HTTP Transport (NEW!)
+## HTTP Transport
 
-The library now supports MCP 2025-03-26 Streamable HTTP transport:
+The library supports MCP 2025-06-18 Streamable HTTP transport with protocol version headers:
 
 ```haskell
 import MCP.Server.Transport.Http
@@ -203,7 +220,8 @@ main = runMcpServerHttpWithConfig customConfig serverInfo handlers
 - CORS enabled for web clients  
 - GET `/mcp` for server discovery
 - POST `/mcp` for JSON-RPC messages
-- Full MCP 2025-03-26 compliance
+- Protocol version negotiation via `MCP-Protocol-Version` header
+- Full MCP 2025-06-18 compliance with backward compatibility
 
 ## Examples
 

--- a/mcp-server.cabal
+++ b/mcp-server.cabal
@@ -15,7 +15,7 @@ name: mcp-server
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version: 0.1.0.14
+version: 0.1.0.15
 -- A short (one-line) description of the package.
 synopsis: Library for building Model Context Protocol (MCP) servers
 -- A longer description of the package.
@@ -187,6 +187,7 @@ test-suite haskell-mcp-server-test
     Spec.JSONConversion
     Spec.SchemaValidation
     Spec.UnicodeHandling
+    Spec.VersionNegotiation
     TestData
     TestTypes
 

--- a/src/MCP/Server.hs
+++ b/src/MCP/Server.hs
@@ -17,7 +17,6 @@ module MCP.Server
   , module MCP.Server.Types
   ) where
 
-import           Control.Monad.IO.Class (MonadIO)
 import           Data.Aeson
 import           Data.Text              (Text)
 import qualified Data.Text              as T

--- a/src/MCP/Server/Derive.hs
+++ b/src/MCP/Server/Derive.hs
@@ -75,8 +75,10 @@ mkPromptDefWithDescription descriptions con =
             Nothing   -> "Handle " ++ constructorName
       [| PromptDefinition
           { promptDefinitionName = $(litE $ stringL $ T.unpack promptName)
+          , promptDefinitionTitle = Nothing
           , promptDefinitionDescription = $(litE $ stringL description)
           , promptDefinitionArguments = []
+          , promptDefinitionMeta = Nothing
           } |]
     RecC name fields -> do
       let promptName = T.pack . toSnakeCase . nameBase $ name
@@ -87,8 +89,10 @@ mkPromptDefWithDescription descriptions con =
       args <- sequence $ map (mkArgDef descriptions) fields
       [| PromptDefinition
           { promptDefinitionName = $(litE $ stringL $ T.unpack promptName)
+          , promptDefinitionTitle = Nothing
           , promptDefinitionDescription = $(litE $ stringL description)
           , promptDefinitionArguments = $(return $ ListE args)
+          , promptDefinitionMeta = Nothing
           } |]
     NormalC name [(_bang, paramType)] -> do
       -- Handle separate parameter types approach
@@ -100,8 +104,10 @@ mkPromptDefWithDescription descriptions con =
       args <- extractFieldsFromType descriptions paramType
       [| PromptDefinition
           { promptDefinitionName = $(litE $ stringL $ T.unpack promptName)
+          , promptDefinitionTitle = Nothing
           , promptDefinitionDescription = $(litE $ stringL description)
           , promptDefinitionArguments = $(return $ ListE args)
+          , promptDefinitionMeta = Nothing
           } |]
     _ -> fail "Unsupported constructor type"
 
@@ -365,10 +371,12 @@ mkResourceDefWithDescription descriptions (NormalC name []) = do
   [| ResourceDefinition
       { resourceDefinitionURI = $(litE $ stringL resourceURI)
       , resourceDefinitionName = $(litE $ stringL $ T.unpack resourceName)
+      , resourceDefinitionTitle = Nothing
       , resourceDefinitionDescription = $(case description of
           Just desc -> [| Just $(litE $ stringL desc) |]
           Nothing   -> [| Nothing |])
       , resourceDefinitionMimeType = Just "text/plain"
+      , resourceDefinitionMeta = Nothing
       } |]
 mkResourceDefWithDescription _ _ = fail "Unsupported constructor type for resources"
 
@@ -423,11 +431,13 @@ mkToolDefWithDescription descriptions con =
             Nothing   -> constructorName
       [| ToolDefinition
           { toolDefinitionName = $(litE $ stringL $ T.unpack toolName)
+          , toolDefinitionTitle = Nothing
           , toolDefinitionDescription = $(litE $ stringL description)
           , toolDefinitionInputSchema = InputSchemaDefinitionObject
               { properties = []
               , required = []
               }
+          , toolDefinitionMeta = Nothing
           } |]
     RecC name fields -> do
       let toolName = T.pack . toSnakeCase . nameBase $ name
@@ -445,11 +455,13 @@ mkToolDefWithDescription descriptions con =
       let required = [f | Just f <- requiredFields]
       [| ToolDefinition
           { toolDefinitionName = $(litE $ stringL $ T.unpack toolName)
+          , toolDefinitionTitle = Nothing
           , toolDefinitionDescription = $(litE $ stringL description)
           , toolDefinitionInputSchema = InputSchemaDefinitionObject
               { properties = $(return $ ListE props)
               , required = $(return $ ListE $ map (LitE . StringL) required)
               }
+          , toolDefinitionMeta = Nothing
           } |]
     NormalC name [(_bang, paramType)] -> do
       -- Handle separate parameter types approach for tools
@@ -469,11 +481,13 @@ mkToolDefWithDescription descriptions con =
       let required = [f | Just f <- requiredFields]
       [| ToolDefinition
           { toolDefinitionName = $(litE $ stringL $ T.unpack toolName)
+          , toolDefinitionTitle = Nothing
           , toolDefinitionDescription = $(litE $ stringL description)
           , toolDefinitionInputSchema = InputSchemaDefinitionObject
               { properties = $(return $ ListE props)
               , required = $(return $ ListE $ map (LitE . StringL) required)
               }
+          , toolDefinitionMeta = Nothing
           } |]
     _ -> fail "Unsupported constructor type for tools"
 

--- a/src/MCP/Server/Handlers.hs
+++ b/src/MCP/Server/Handlers.hs
@@ -61,10 +61,11 @@ getMessageSummary (JsonRpcMessageResponse resp) =
 -- | Validate protocol version and return negotiated version
 validateProtocolVersion :: Text -> Either Text Text
 validateProtocolVersion clientVersion
-  | clientVersion == protocolVersion = Right protocolVersion  -- Exact match (2025-03-26)
-  | clientVersion == "2025-03-26" = Right "2025-03-26"        -- Accept latest version
+  | clientVersion == protocolVersion = Right protocolVersion  -- Exact match (2025-06-18)
+  | clientVersion == "2025-06-18" = Right "2025-06-18"        -- Accept latest version
+  | clientVersion == "2025-03-26" = Right "2025-03-26"        -- Accept previous version
   | clientVersion == "2024-11-05" = Right "2024-11-05"        -- Accept legacy version
-  | otherwise = Left $ "Unsupported protocol version: " <> clientVersion <> ". Server supports: 2025-03-26, 2024-11-05"
+  | otherwise = Left $ "Unsupported protocol version: " <> clientVersion <> ". Server supports: 2025-06-18, 2025-03-26, 2024-11-05"
 
 -- | Handle an MCP message and return a response if needed
 handleMcpMessage :: (MonadIO m)
@@ -139,6 +140,7 @@ handleInitialize serverInfo req = do
                     { initRespProtocolVersion = negotiatedVersion
                     , initRespCapabilities = capabilities
                     , initRespServerInfo = serverInfo
+                    , initRespMeta = Nothing
                     }
               return $ makeSuccessResponse (requestId req) (toJSON response)
 

--- a/src/MCP/Server/Protocol.hs
+++ b/src/MCP/Server/Protocol.hs
@@ -38,12 +38,13 @@ module MCP.Server.Protocol
 
 import           Data.Aeson
 import           Data.Map         (Map)
+import           Data.Maybe       (catMaybes)
 import           Data.Text        (Text)
 import           GHC.Generics     (Generic)
 import           MCP.Server.Types
 
 protocolVersion :: Text
-protocolVersion = "2025-03-26"
+protocolVersion = "2025-06-18"
 
 
 -- | Initialize request
@@ -64,17 +65,19 @@ data InitializeResponse = InitializeResponse
   { initRespProtocolVersion :: Text
   , initRespCapabilities    :: ServerCapabilities
   , initRespServerInfo      :: McpServerInfo
+  , initRespMeta            :: Maybe Value
   } deriving (Show, Eq, Generic)
 
 instance ToJSON InitializeResponse where
-  toJSON resp = object
-    [ "protocolVersion" .= initRespProtocolVersion resp
-    , "capabilities" .= initRespCapabilities resp
-    , "serverInfo" .= object
+  toJSON resp = object $ catMaybes
+    [ Just ("protocolVersion" .= initRespProtocolVersion resp)
+    , Just ("capabilities" .= initRespCapabilities resp)
+    , Just ("serverInfo" .= object
         [ "name" .= serverName (initRespServerInfo resp)
         , "version" .= serverVersion (initRespServerInfo resp)
         , "instructions" .= serverInstructions (initRespServerInfo resp)
-        ]
+        ])
+    , fmap ("_meta" .=) (initRespMeta resp)
     ]
 
 -- | Initialized notification (no parameters)

--- a/src/MCP/Server/Protocol.hs
+++ b/src/MCP/Server/Protocol.hs
@@ -51,14 +51,14 @@ protocolVersion = "2025-06-18"
 data InitializeRequest = InitializeRequest
   { initProtocolVersion :: Text
   , initCapabilities    :: Value
-  , initClientInfo      :: Value
+  , initClientInfo      :: Maybe Value
   } deriving (Show, Eq, Generic)
 
 instance FromJSON InitializeRequest where
   parseJSON = withObject "InitializeRequest" $ \o -> InitializeRequest
     <$> o .: "protocolVersion"
     <*> o .: "capabilities"
-    <*> o .: "clientInfo"
+    <*> o .:? "clientInfo"
 
 -- | Initialize response
 data InitializeResponse = InitializeResponse

--- a/src/MCP/Server/Transport/Stdio.hs
+++ b/src/MCP/Server/Transport/Stdio.hs
@@ -6,14 +6,15 @@ module MCP.Server.Transport.Stdio
     transportRunStdio
   ) where
 
-import           Control.Monad          (when)
+import           Control.Exception      (catch, IOException)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Aeson
 import qualified Data.ByteString.Lazy   as BSL
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as TE
 import qualified Data.Text.IO           as TIO
-import           System.IO              (hFlush, hPutStrLn, stderr, stdout)
+import           System.IO              (hFlush, stderr, stdout)
+import           System.IO.Error        (isEOFError)
 
 import           MCP.Server.Handlers
 import           MCP.Server.JsonRpc
@@ -32,24 +33,51 @@ transportRunStdio serverInfo handlers = do
   loop
   where
     loop = do
-      input <- liftIO TIO.getLine
-      when (not $ T.null $ T.strip input) $ do
-        -- Use TIO.hPutStrLn for UTF-8 output
-        liftIO $ TIO.hPutStrLn stderr $ "Received request: " <> input
-        case eitherDecode (BSL.fromStrict $ TE.encodeUtf8 input) of
-          Left err -> liftIO $ TIO.hPutStrLn stderr $ "Parse error: " <> T.pack err
-          Right jsonValue -> do
-            case parseJsonRpcMessage jsonValue of
-              Left err -> liftIO $ TIO.hPutStrLn stderr $ "JSON-RPC parse error: " <> T.pack err
-              Right message -> do
-                liftIO $ TIO.hPutStrLn stderr $ "Processing message: " <> T.pack (show (getMessageSummary message))
-                response <- handleMcpMessage serverInfo handlers message
-                case response of
-                  Just responseMsg -> do
-                    liftIO $ TIO.hPutStrLn stderr $ "Sending response for: " <> T.pack (show (getMessageSummary message))
-                    let responseText = TE.decodeUtf8 $ BSL.toStrict $ encode $ encodeJsonRpcMessage responseMsg
-                    liftIO $ TIO.putStrLn responseText
-                    liftIO $ hFlush stdout
-                  Nothing -> liftIO $ TIO.hPutStrLn stderr $ "No response needed for: " <> T.pack (show (getMessageSummary message))
-        loop
+      -- Catch EOF exception when stdin is closed
+      inputResult <- liftIO $ (Just <$> TIO.getLine) `catch` handleEOF
+      case inputResult of
+        Nothing ->
+          -- EOF encountered, exit gracefully
+          liftIO $ TIO.hPutStrLn stderr "MCP server: stdin closed (EOF), shutting down gracefully"
+        Just input
+          | not $ T.null $ T.strip input -> do
+              -- Use TIO.hPutStrLn for UTF-8 output
+              liftIO $ TIO.hPutStrLn stderr $ "Received request: " <> input
+              case eitherDecode $ BSL.fromStrict $ TE.encodeUtf8 input of
+                Left err -> do
+                  liftIO $ TIO.hPutStrLn stderr $ "Parse error: " <> T.pack err
+                  loop
+                Right jsonValue -> do
+                  case parseJsonRpcMessage jsonValue of
+                    Left err -> do
+                      liftIO $ TIO.hPutStrLn stderr $ "JSON-RPC parse error: " <> T.pack err
+                      loop
+                    Right message -> do
+                      liftIO $ TIO.hPutStrLn stderr $ "Processing message: " <> T.pack (show (getMessageSummary message))
+                      response <- handleMcpMessage serverInfo handlers message
+                      case response of
+                        Just responseMsg -> do
+                          liftIO $ TIO.hPutStrLn stderr $ "Sending response for: " <> T.pack (show (getMessageSummary message))
+                          let responseText = TE.decodeUtf8 $ BSL.toStrict $ encode $ encodeJsonRpcMessage responseMsg
+                          -- Handle broken pipe when writing response
+                          writeResult <- liftIO $ (TIO.putStrLn responseText >> hFlush stdout >> return True) `catch` handleBrokenPipe
+                          if writeResult
+                            then loop  -- Continue normally
+                            else liftIO $ TIO.hPutStrLn stderr "MCP server: stdout closed (broken pipe), shutting down" -- Signal to stop looping
+                        Nothing -> do
+                          liftIO $ TIO.hPutStrLn stderr $ "No response needed for: " <> T.pack (show (getMessageSummary message))
+                          loop
+          | otherwise -> loop
+
+    handleEOF :: IOException -> IO (Maybe T.Text)
+    handleEOF e
+      | isEOFError e = return Nothing
+      | otherwise = ioError e  -- Re-throw non-EOF exceptions
+
+    handleBrokenPipe :: IOException -> IO Bool
+    handleBrokenPipe e
+      | isEOFError e = return False  -- Treat EOF on stdout as broken pipe
+      | "Broken pipe" `T.isInfixOf` T.pack (show e) = return False
+      | "Resource vanished" `T.isInfixOf` T.pack (show e) = return False
+      | otherwise = ioError e  -- Re-throw other exceptions
 

--- a/src/MCP/Server/Types.hs
+++ b/src/MCP/Server/Types.hs
@@ -196,13 +196,17 @@ data PromptDefinition = PromptDefinition
   { promptDefinitionName        :: Text
   , promptDefinitionDescription :: Text
   , promptDefinitionArguments   :: [ArgumentDefinition]
+  , promptDefinitionTitle       :: Maybe Text
+  , promptDefinitionMeta        :: Maybe Value
   } deriving (Show, Eq, Generic)
 
 instance ToJSON PromptDefinition where
-  toJSON def = object
-    [ "name" .= promptDefinitionName def
-    , "description" .= promptDefinitionDescription def
-    , "arguments" .= promptDefinitionArguments def
+  toJSON def = object $ catMaybes
+    [ Just ("name" .= promptDefinitionName def)
+    , Just ("description" .= promptDefinitionDescription def)
+    , Just ("arguments" .= promptDefinitionArguments def)
+    , fmap ("title" .=) (promptDefinitionTitle def)
+    , fmap ("_meta" .=) (promptDefinitionMeta def)
     ]
 
 -- | Resource definition
@@ -211,28 +215,36 @@ data ResourceDefinition = ResourceDefinition
   , resourceDefinitionName        :: Text
   , resourceDefinitionDescription :: Maybe Text
   , resourceDefinitionMimeType    :: Maybe Text
+  , resourceDefinitionTitle       :: Maybe Text
+  , resourceDefinitionMeta        :: Maybe Value
   } deriving (Show, Eq, Generic)
 
 instance ToJSON ResourceDefinition where
-  toJSON def = object $
-    [ "uri" .= resourceDefinitionURI def
-    , "name" .= resourceDefinitionName def
-    ] ++
-    maybe [] (\d -> ["description" .= d]) (resourceDefinitionDescription def) ++
-    maybe [] (\m -> ["mimeType" .= m]) (resourceDefinitionMimeType def)
+  toJSON def = object $ catMaybes
+    [ Just ("uri" .= resourceDefinitionURI def)
+    , Just ("name" .= resourceDefinitionName def)
+    , fmap ("description" .=) (resourceDefinitionDescription def)
+    , fmap ("mimeType" .=) (resourceDefinitionMimeType def)
+    , fmap ("title" .=) (resourceDefinitionTitle def)
+    , fmap ("_meta" .=) (resourceDefinitionMeta def)
+    ]
 
 -- | Tool definition
 data ToolDefinition = ToolDefinition
   { toolDefinitionName        :: Text
   , toolDefinitionDescription :: Text
   , toolDefinitionInputSchema :: InputSchemaDefinition
+  , toolDefinitionTitle       :: Maybe Text
+  , toolDefinitionMeta        :: Maybe Value
   } deriving (Show, Eq, Generic)
 
 instance ToJSON ToolDefinition where
-  toJSON def = object
-    [ "name" .= toolDefinitionName def
-    , "description" .= toolDefinitionDescription def
-    , "inputSchema" .= toolDefinitionInputSchema def
+  toJSON def = object $ catMaybes
+    [ Just ("name" .= toolDefinitionName def)
+    , Just ("description" .= toolDefinitionDescription def)
+    , Just ("inputSchema" .= toolDefinitionInputSchema def)
+    , fmap ("title" .=) (toolDefinitionTitle def)
+    , fmap ("_meta" .=) (toolDefinitionMeta def)
     ]
 
 -- | Argument definition for prompts

--- a/test/HspecMain.hs
+++ b/test/HspecMain.hs
@@ -8,6 +8,7 @@ import qualified Spec.BasicDerivation
 import qualified Spec.SchemaValidation
 import qualified Spec.AdvancedDerivation
 import qualified Spec.UnicodeHandling
+import qualified Spec.VersionNegotiation
 
 main :: IO ()
 main = hspec $ do
@@ -17,3 +18,4 @@ main = hspec $ do
     Spec.SchemaValidation.spec
     Spec.AdvancedDerivation.spec
     Spec.UnicodeHandling.spec
+    Spec.VersionNegotiation.spec

--- a/test/Spec/UnicodeHandling.hs
+++ b/test/Spec/UnicodeHandling.hs
@@ -167,8 +167,10 @@ spec = describe "Unicode Handling" $ do
       let promptListHandler = return [
             PromptDefinition
               { promptDefinitionName = "math_formula"
+              , promptDefinitionTitle = Nothing
               , promptDefinitionDescription = "Generate mathematical formulas with Unicode: ∀∃∈√"
               , promptDefinitionArguments = [ArgumentDefinition "formula" "Mathematical expression" True]
+              , promptDefinitionMeta = Nothing
               }
             ]
 
@@ -182,8 +184,10 @@ spec = describe "Unicode Handling" $ do
             ResourceDefinition
               { resourceDefinitionURI = "resource://unicode_symbols"
               , resourceDefinitionName = "unicode_symbols"
+              , resourceDefinitionTitle = Nothing
               , resourceDefinitionDescription = Just "Unicode mathematical symbols: ∀∃∈∉√∑"
               , resourceDefinitionMimeType = Just "text/plain"
+              , resourceDefinitionMeta = Nothing
               }
             ]
 
@@ -195,11 +199,13 @@ spec = describe "Unicode Handling" $ do
       let toolListHandler = return [
             ToolDefinition
               { toolDefinitionName = "calculate"
+              , toolDefinitionTitle = Nothing
               , toolDefinitionDescription = "Calculate with Unicode symbols: √∑∏"
               , toolDefinitionInputSchema = InputSchemaDefinitionObject
                   { properties = [("expression", InputSchemaDefinitionProperty "string" "Mathematical expression")]
                   , required = ["expression"]
                   }
+              , toolDefinitionMeta = Nothing
               }
             ]
 

--- a/test/Spec/VersionNegotiation.hs
+++ b/test/Spec/VersionNegotiation.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Spec.VersionNegotiation (spec) where
+
+import Data.Aeson (Value(..), object, (.=))
+import Data.Text (Text)
+import qualified Data.Text as T
+import MCP.Server.Handlers (validateProtocolVersion)
+import MCP.Server.Protocol (protocolVersion)
+import MCP.Server.Types
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Protocol Version Negotiation" $ do
+  describe "validateProtocolVersion" $ do
+    it "accepts 2025-06-18 (latest)" $ do
+      validateProtocolVersion "2025-06-18" `shouldBe` Right "2025-06-18"
+    
+    it "accepts 2025-03-26 (previous)" $ do
+      validateProtocolVersion "2025-03-26" `shouldBe` Right "2025-03-26"
+    
+    it "accepts 2024-11-05 (legacy)" $ do
+      validateProtocolVersion "2024-11-05" `shouldBe` Right "2024-11-05"
+    
+    it "rejects unknown versions" $ do
+      case validateProtocolVersion "2023-01-01" of
+        Left err -> T.unpack err `shouldContain` "Unsupported protocol version"
+        Right _ -> expectationFailure "Should have rejected unknown version"
+    
+    it "rejects empty version" $ do
+      case validateProtocolVersion "" of
+        Left err -> T.unpack err `shouldContain` "Unsupported protocol version"
+        Right _ -> expectationFailure "Should have rejected empty version"
+
+  describe "protocolVersion constant" $ do
+    it "is set to 2025-06-18" $ do
+      protocolVersion `shouldBe` "2025-06-18"
+
+  describe "backwards compatibility" $ do
+    it "supports all three versions" $ do
+      let versions = ["2025-06-18", "2025-03-26", "2024-11-05"]
+          isRight (Right _) = True
+          isRight (Left _) = False
+      mapM_ (\v -> validateProtocolVersion v `shouldSatisfy` isRight) versions
+
+  describe "new fields" $ do
+    it "creates PromptDefinition with new fields" $ do
+      let prompt = PromptDefinition
+            { promptDefinitionName = "test"
+            , promptDefinitionTitle = Just "Test Prompt"
+            , promptDefinitionDescription = "A test prompt"
+            , promptDefinitionArguments = []
+            , promptDefinitionMeta = Just (object ["version" .= ("1.0" :: Text)])
+            }
+      promptDefinitionName prompt `shouldBe` "test"
+      promptDefinitionTitle prompt `shouldBe` Just "Test Prompt"
+      promptDefinitionMeta prompt `shouldNotBe` Nothing
+    
+    it "creates ResourceDefinition with new fields" $ do
+      let resource = ResourceDefinition
+            { resourceDefinitionURI = "resource://test"
+            , resourceDefinitionName = "test"
+            , resourceDefinitionTitle = Just "Test Resource"
+            , resourceDefinitionDescription = Just "A test resource"
+            , resourceDefinitionMimeType = Just "text/plain"
+            , resourceDefinitionMeta = Nothing
+            }
+      resourceDefinitionName resource `shouldBe` "test"
+      resourceDefinitionTitle resource `shouldBe` Just "Test Resource"
+    
+    it "creates ToolDefinition with new fields" $ do
+      let tool = ToolDefinition
+            { toolDefinitionName = "test"
+            , toolDefinitionTitle = Just "Test Tool"
+            , toolDefinitionDescription = "A test tool"
+            , toolDefinitionInputSchema = InputSchemaDefinitionObject
+                { properties = []
+                , required = []
+                }
+            , toolDefinitionMeta = Nothing
+            }
+      toolDefinitionName tool `shouldBe` "test"
+      toolDefinitionTitle tool `shouldBe` Just "Test Tool"


### PR DESCRIPTION
Claude code was giving me issues because mcp-server only supported MCP protocol version 2025-03-26. This PR aims to add some level of support for MCP 2025-06-18, at least enough to make it work for Claude Code.