### PR TITLE
Bump package version to 0.1.0.19

### DIFF
--- a/mcp-server.cabal
+++ b/mcp-server.cabal
@@ -15,7 +15,7 @@ name: mcp-server
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version: 0.1.0.18
+version: 0.1.0.19
 -- A short (one-line) description of the package.
 synopsis: Library for building Model Context Protocol (MCP) servers
 -- A longer description of the package.


### PR DESCRIPTION
I see 0.1.0.18 has already been release to hackage, so this is just bumping version for the next release.