### PR TITLE
Fix protocol negotiation: echo back compatible older versions

### DIFF
--- a/mcp-server.cabal
+++ b/mcp-server.cabal
@@ -15,7 +15,7 @@ name: mcp-server
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version: 0.1.0.19
+version: 0.1.0.20
 -- A short (one-line) description of the package.
 synopsis: Library for building Model Context Protocol (MCP) servers
 -- A longer description of the package.

--- a/src/MCP/Server/Handlers.hs
+++ b/src/MCP/Server/Handlers.hs
@@ -58,14 +58,28 @@ getMessageSummary (JsonRpcMessageNotification notif) =
 getMessageSummary (JsonRpcMessageResponse resp) =
   "Response[" ++ show (responseId resp) ++ "]"
 
--- | Validate protocol version and return negotiated version
--- Per MCP spec: "If the server supports the requested protocol version,
--- it MUST respond with the same version. Otherwise, the server MUST respond
--- with another protocol version it supports."
+-- | Validate protocol version and return negotiated version.
+--
+-- Per MCP spec the server must respond with a version it supports that is
+-- less than or equal to the client's proposed version. Responding with a
+-- NEWER version causes well-behaved clients (e.g. Claude Code) to disconnect,
+-- since they cannot be expected to understand a protocol they haven't
+-- implemented yet.
+--
+-- Known compatible older versions are echoed back verbatim because the wire
+-- format for basic tool\/resource\/prompt operations has not changed.
 validateProtocolVersion :: Text -> Either Text Text
 validateProtocolVersion clientVersion
-  | clientVersion == protocolVersion = Right protocolVersion  -- Exact match
-  | otherwise = Right protocolVersion  -- Negotiate: return server's supported version
+  | clientVersion == protocolVersion = Right protocolVersion    -- Exact match
+  | clientVersion `elem` compatibleOlderVersions = Right clientVersion  -- Compatible older version
+  | otherwise = Right protocolVersion                          -- Unknown: best-effort
+
+-- | Older protocol versions whose wire format is compatible with ours
+-- for basic operations (tools, resources, prompts).
+compatibleOlderVersions :: [Text]
+compatibleOlderVersions =
+  [ "2024-11-05"  -- Used by Claude Code; wire-compatible for tool/resource/prompt calls
+  ]
 
 -- | Handle an MCP message and return a response if needed
 handleMcpMessage :: (MonadIO m)

--- a/test/Spec/ProtocolVersionNegotiation.hs
+++ b/test/Spec/ProtocolVersionNegotiation.hs
@@ -112,3 +112,42 @@ spec = describe "Protocol Version Negotiation" $ do
               Just other -> expectationFailure $ "protocolVersion is not a string: " ++ show other
               Nothing -> expectationFailure "Response missing protocolVersion"
           Just other -> expectationFailure $ "Result is not an object: " ++ show other
+
+  it "Server should echo back older compatible version instead of responding with a newer one" $ do
+    -- Claude Code sends "2024-11-05". Per MCP spec the server MUST respond
+    -- with a version <= what the client proposed, because the client cannot
+    -- be expected to understand a protocol version newer than what it asked for.
+    -- The 2024-11-05 wire format is compatible with 2025-06-18 for basic
+    -- tool/resource/prompt operations, so the server should accept it.
+    let params = object
+          [ "protocolVersion" .= String "2024-11-05"  -- Older version (Claude Code)
+          , "capabilities" .= object []
+          , "clientInfo" .= object
+              [ "name" .= String "claude-code"
+              , "version" .= String "2.1.66"
+              ]
+          ]
+        request = JsonRpcRequest
+          { requestJsonrpc = "2.0"
+          , requestId = RequestIdNumber 0
+          , requestMethod = "initialize"
+          , requestParams = Just params
+          }
+
+    response <- handleInitialize testServerInfo request
+
+    case responseError response of
+      Just err -> expectationFailure $ "Unexpected error: " ++ show (errorMessage err)
+      Nothing -> do
+        case responseResult response of
+          Nothing -> expectationFailure "Response has no result"
+          Just (Object result) -> do
+            case KM.lookup "protocolVersion" result of
+              Just (String version) -> do
+                -- Server must NOT respond with a version newer than what
+                -- the client proposed. Responding with "2025-06-18" when
+                -- client sent "2024-11-05" causes the client to disconnect.
+                version `shouldBe` "2024-11-05"
+              Just other -> expectationFailure $ "protocolVersion is not a string: " ++ show other
+              Nothing -> expectationFailure "Response missing protocolVersion"
+          Just other -> expectationFailure $ "Result is not an object: " ++ show other


### PR DESCRIPTION
## Summary
- Server was always responding with `"2025-06-18"` regardless of what the client proposed
- Claude Code sends `"2024-11-05"` and disconnects when it receives a higher version back, causing tools to never appear
- Per MCP spec, server must respond with a version <= the client's proposed version
- Fix: introduce `compatibleOlderVersions` list; echo back any known compatible version instead of always returning the server's own

## Reproducer
The first commit adds a failing test showing the bug:
```
expected: "2024-11-05"
 but got: "2025-06-18"
```

The second commit fixes `validateProtocolVersion` to echo back `"2024-11-05"` since the wire format for basic tool/resource/prompt operations is compatible.

## Test plan
- [x] New test asserts server responds with `"2024-11-05"` when client proposes it
- [x] Existing tests still pass (57 examples, 0 failures)
- [ ] Verified with Claude Code that tools now appear after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)