### PR TITLE
Echo client-requested protocol version for wire-compatible revisions

### DIFF
--- a/mcp-server.cabal
+++ b/mcp-server.cabal
@@ -15,7 +15,7 @@ name: mcp-server
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version: 0.1.0.19
+version: 0.1.0.20
 -- A short (one-line) description of the package.
 synopsis: Library for building Model Context Protocol (MCP) servers
 -- A longer description of the package.

--- a/src/MCP/Server/Handlers.hs
+++ b/src/MCP/Server/Handlers.hs
@@ -58,14 +58,36 @@ getMessageSummary (JsonRpcMessageNotification notif) =
 getMessageSummary (JsonRpcMessageResponse resp) =
   "Response[" ++ show (responseId resp) ++ "]"
 
--- | Validate protocol version and return negotiated version
--- Per MCP spec: "If the server supports the requested protocol version,
--- it MUST respond with the same version. Otherwise, the server MUST respond
--- with another protocol version it supports."
+-- | Validate protocol version and return negotiated version.
+--
+-- Per MCP spec: "If the server supports the requested protocol version, it MUST
+-- respond with the same version. Otherwise, the server MUST respond with
+-- another protocol version it supports."
+--
+-- The wire format for the basic tool\/resource\/prompt operations exposed by
+-- this library has not changed across the date-versioned protocol revisions, so
+-- any version the client explicitly proposes from 'compatibleVersions' is echoed
+-- back verbatim. This satisfies clients (e.g. Claude Code) that request a newer
+-- revision than this library's nominal 'protocolVersion' and would otherwise
+-- warn about an unsupported version. Unknown versions fall back to the server's
+-- own 'protocolVersion'.
 validateProtocolVersion :: Text -> Either Text Text
 validateProtocolVersion clientVersion
-  | clientVersion == protocolVersion = Right protocolVersion  -- Exact match
-  | otherwise = Right protocolVersion  -- Negotiate: return server's supported version
+  | clientVersion == protocolVersion          = Right protocolVersion  -- Exact match
+  | clientVersion `elem` compatibleVersions    = Right clientVersion    -- Wire-compatible: echo back
+  | otherwise                                  = Right protocolVersion  -- Unknown: best-effort
+
+-- | Protocol revisions whose wire format is compatible with this library's
+-- implementation for basic tool\/resource\/prompt operations. The client's
+-- proposed version is echoed back when it appears here, so the negotiated
+-- version matches what the client asked for.
+compatibleVersions :: [Text]
+compatibleVersions =
+  [ "2024-11-05"
+  , "2025-03-26"
+  , "2025-06-18"
+  , "2025-11-25"
+  ]
 
 -- | Handle an MCP message and return a response if needed
 handleMcpMessage :: (MonadIO m)


### PR DESCRIPTION
## Problem

`validateProtocolVersion` always responds to `initialize` with the server's hardcoded `protocolVersion` (`2025-06-18`), regardless of what the client proposed:

```haskell
validateProtocolVersion clientVersion
  | clientVersion == protocolVersion = Right protocolVersion  -- Exact match
  | otherwise = Right protocolVersion  -- Negotiate: return server's supported version
```

A client requesting a newer revision — e.g. Claude Code, which proposes `2025-11-25` — receives `2025-06-18` back and warns:

> Unsupported protocol version: 2025-11-25. Server only supports: 2025-06-18

Per the MCP spec, *"If the server supports the requested protocol version, it MUST respond with the same version."*

## Change

Echo back any version the client proposes that appears in a `compatibleVersions` list (`2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`). The wire format for the basic tool/resource/prompt operations this library implements is unchanged across these date-versioned revisions, so echoing the client's own requested version is safe. Unknown versions still fall back to the server's `protocolVersion`.

## Verification

A downstream stdio server now returns the requested version:

```
→ initialize { protocolVersion: "2025-11-25" }
← result    { protocolVersion: "2025-11-25" }
```

instead of `2025-06-18`, so the client warning no longer appears.